### PR TITLE
Moving logic from controller to service

### DIFF
--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,6 @@
+import { ApiModelProperty } from '@nestjs/swagger';
+
+export class CreateUserDto {
+  @ApiModelProperty() readonly firstName: string;
+  @ApiModelProperty() readonly lastName: string;
+}

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,7 +1,6 @@
 import { ApiModelProperty } from '@nestjs/swagger';
 
 export class UpdateUserDto {
-  @ApiModelProperty() readonly id: number;
   @ApiModelProperty() readonly firstName: string;
   @ApiModelProperty() readonly lastName: string;
 }

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,0 +1,7 @@
+import { ApiModelProperty } from '@nestjs/swagger';
+
+export class UpdateUserDto {
+  @ApiModelProperty() readonly id: number;
+  @ApiModelProperty() readonly firstName: string;
+  @ApiModelProperty() readonly lastName: string;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,50 +1,37 @@
 import { Controller, Get, Post, Delete, Put, Param, Body } from '@nestjs/common';
-import { ApiModelProperty } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { User } from './user.entity';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 
-export class CreateDto {
-  @ApiModelProperty() firstName: string;
-  @ApiModelProperty() lastName: string;
-}
-
-export class UpdateDto extends CreateDto {}
+export class UpdateDto extends CreateUserDto {}
 
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get()
-  async findAll(): Promise<User[]> {
-    return this.usersService.findAll();
-  }
-
-  @Get()
-  index() {
-    return User.findAll();
+  async index(): Promise<User[]> {
+    return this.usersService.index();
   }
 
   @Get(':id')
-  show(@Param('id') id: number) {
-    return User.findById(id);
+  async show(@Param('id') userId: number) {
+    return this.usersService.show(userId);
   }
 
   @Post()
-  create(@Body() body: CreateDto) {
-    return User.create(body);
+  async create(@Body() createUserDto: CreateUserDto) {
+    await this.usersService.create(createUserDto);
   }
 
   @Put(':id')
-  async update(@Param('id') id: number, @Body() body: UpdateDto) {
-    const user = await User.findById(id)
-    user.update(body) // async update
-    return user
+  async update(@Param('id') userId: number, @Body() updateUserDto: UpdateUserDto) {
+    await this.usersService.update(userId, updateUserDto);
   }
 
   @Delete(':id')
-  async destroy(@Param('id') id: number){
-    const user = await User.findById(id)
-    user.destroy({ force: true })
-    return user
+  async destroy(@Param('id') userId: number){
+    await this.usersService.destroy(userId);
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -4,8 +4,6 @@ import { User } from './user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 
-export class UpdateDto extends CreateUserDto {}
-
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Inject } from '@nestjs/common';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from './user.entity';
 
 @Injectable()
@@ -8,7 +10,33 @@ export class UsersService {
     @Inject('UsersRepository') private readonly usersRepository: typeof User) {}
     // private readonly userService: User) {}
 
-  async findAll(): Promise<User[]> {
+  async index(): Promise<User[]> {
     return await this.usersRepository.findAll<User>();
   }
+
+  async show(userId: number): Promise<User> {
+    return await this.usersRepository.findById(userId);
+  }
+
+  async create(createUserDto: CreateUserDto): Promise<User> {
+    const user = new User();
+    user.firstName = createUserDto.firstName;
+    user.lastName = createUserDto.lastName;
+
+    return await user.save();
+  }
+
+  async update(userId: number, updateUserDto: UpdateUserDto): Promise<User> {
+    const user = await User.findById(userId);
+    return await user.update(updateUserDto)
+  }
+
+  async destroy(userId: number): Promise<User> {
+    const user = await User.findById(userId)
+    user.destroy({ force: true })
+    return user
+  }
 }
+
+
+

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -37,6 +37,3 @@ export class UsersService {
     return user
   }
 }
-
-
-


### PR DESCRIPTION
Se mueve toda la lógica del controlador de usuarios al servicio de usuarios.

El controlador ha de ser "tonto" en cuanto a esta lógica, solo saber a que métodos invocar.

Se ha seguido la convención del framework

También se ha creado la darpeta `dto` en usuarios para que quede aparte y pueda incluirse en el servicio de usuarios y en el controlador.