### PR TITLE
disable cors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors({ origin: '*' });
   const options = new DocumentBuilder()
     .setTitle('Users example')
     .setDescription('The users API description')


### PR DESCRIPTION
For use the api from client side, we need to disable cors.

Nestjs use [cors](https://github.com/nestjs/nest/pull/458/files) [pacakge](https://www.npmjs.com/package/cors) to handler this. 
```ts
const app = await NestFactory.create(AppModule);
app.enableCors({ origin: '*' });
```