### PR TITLE
Internationalization (I18n)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "email-templates": "^5.0.2",
     "graphql": "^14.0.2",
     "graphql-tools": "^4.0.3",
+    "i18n": "^0.8.3",
     "ioredis": "^4.2.0",
     "kue": "^0.11.6",
     "mysql2": "^1.6.1",

--- a/src/i18n/i18n.spec.ts
+++ b/src/i18n/i18n.spec.ts
@@ -1,0 +1,49 @@
+import I18n from './i18n';
+
+describe('I18n', () => {
+  it('translate', async () => {
+    I18n.setLocale('es');
+    expect(I18n.__('Welcome')).toBe('Bienvenido');
+  });
+
+  it('translate falback en locale', async () => {
+    I18n.setLocale('br');
+    expect(I18n.__('Welcome')).toBe('Welcome');
+  });
+
+  it('translate in paralell global object fail', async () => {
+    I18n.setLocale('es');
+    const [es, en, es2] = await Promise.all([
+      new Promise((resolve, reject) => {
+        resolve(I18n.__('Welcome'));
+      }),
+      new Promise((resolve, reject) => {
+        I18n.setLocale('en');
+        resolve(I18n.__('Welcome'));
+      }),
+      new Promise((resolve, reject) => {
+        resolve(I18n.__('Welcome'));
+      }),
+    ]);
+    expect(es).toBe('Bienvenido');
+    expect(es).toBe('Bienvenido');
+    expect(es2).not.toBe('Bienvenido');
+  });
+
+  it('translate in paralell no use global traslate object', async () => {
+    const [es, en, es2] = await Promise.all([
+      new Promise((resolve, reject) => {
+        resolve(I18n.t('Welcome', { locale: 'es' }));
+      }),
+      new Promise((resolve, reject) => {
+        resolve(I18n.t('Welcome', { locale: 'en' }));
+      }),
+      new Promise((resolve, reject) => {
+        resolve(I18n.t('Welcome', { locale: 'es' }));
+      }),
+    ]);
+    expect(es).toBe('Bienvenido');
+    expect(en).toBe('Welcome');
+    expect(es2).toBe('Bienvenido');
+  });
+});

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,0 +1,12 @@
+const i18n = require('i18n');
+
+i18n.configure({
+  locales: ['en', 'es'],
+  directory: __dirname + '/locales',
+});
+
+// Use in background jobs or async functions
+i18n.t = (phrase: string, { locale = 'en' }: any) =>
+  i18n.__({ phrase, locale });
+
+export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,3 @@
+{
+	"Welcome": "Welcome"
+}

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1,0 +1,3 @@
+{
+  "Welcome": "Bienvenido"
+}

--- a/src/mailer/emails/welcome/html.pug
+++ b/src/mailer/emails/welcome/html.pug
@@ -1,1 +1,1 @@
-<b>Welcome #{name}</b>
+<b>#{t.welcome} #{name}</b>

--- a/src/mailer/welcome.mailer.spec.ts
+++ b/src/mailer/welcome.mailer.spec.ts
@@ -8,5 +8,7 @@ describe('Mailer welcome', () => {
     });
     expect(typeof html).toBe('string');
     expect(typeof text).toBe('string');
+    expect(html).toBe('<b>Bienvenido Example</b>');
+    expect(text).toBe('Bienvenido Example');
   });
 });

--- a/src/mailer/welcome.mailer.spec.ts
+++ b/src/mailer/welcome.mailer.spec.ts
@@ -1,0 +1,12 @@
+import { welcomeEmailTemplate } from './welcome.mailer';
+import { mockTransporter } from './mailer.provider';
+describe('Mailer welcome', () => {
+  it('welcomeEmailTemplate', async () => {
+    const { html, text } = await welcomeEmailTemplate({
+      to: 'user@example.com',
+      name: 'Example',
+    });
+    expect(typeof html).toBe('string');
+    expect(typeof text).toBe('string');
+  });
+});

--- a/src/mailer/welcome.mailer.ts
+++ b/src/mailer/welcome.mailer.ts
@@ -13,7 +13,10 @@ export const WelcomeEmail = transporter => ({ to, name }) => {
   });
 };
 
-const welcomeEmailTemplate = async ({ to, name }) => {
+export const welcomeEmailTemplate = async ({
+  to,
+  name,
+}): Promise<{ html: string; text: string }> => {
   const email = new Email();
   return email.renderAll(path.join(__dirname, 'emails', 'welcome'), {
     to,

--- a/src/mailer/welcome.mailer.ts
+++ b/src/mailer/welcome.mailer.ts
@@ -1,3 +1,4 @@
+import I18n from '../i18n/i18n';
 const path = require('path');
 const Email = require('email-templates');
 
@@ -21,5 +22,8 @@ export const welcomeEmailTemplate = async ({
   return email.renderAll(path.join(__dirname, 'emails', 'welcome'), {
     to,
     name,
+    t: {
+      welcome: I18n.t('Welcome', { locale: 'es' }),
+    },
   });
 };


### PR DESCRIPTION
Use package [i18n](https://www.npmjs.com/package/i18n)

For use in emails templates translate before send to the email template.

To avoid change locale in async or backgrup job pass the locale as parameter.
```typescript
I18n.t('Translate', {locale: 'es'})
```